### PR TITLE
Add cross‑platform installer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,35 @@ Convert all files in a directory:
      -p:PublishSingleFile=false \
      -p:PublishTrimmed=false \
      --self-contained true \
-     -o dist/PioneerConverter-osx-arm64
-   ```
+   -o dist/PioneerConverter-osx-arm64
+  ```
+
+## Building Installers
+
+Installer scripts are provided for Windows, macOS and Linux under the
+`installers/` directory.  These scripts package the binaries produced by
+`build.sh` into native installers and place a wrapper on the system `PATH`.
+
+### Windows
+
+Use [Inno Setup](https://jrsoftware.org/isinfo.php) to compile
+`installers/windows/PioneerConverter.iss`.  The resulting
+`PioneerConverter-Setup.exe` installs the application under
+`Program Files` and can optionally add the directory to your `PATH`.
+
+### macOS
+
+Run `installers/macos/build_pkg.sh` on a Mac with Xcode command line tools.
+It produces `PioneerConverter.pkg` which installs files to
+`/usr/local/PioneerConverter` and symlinks the `pioneerconverter` command to
+`/usr/local/bin`.
+
+### Linux
+
+Run `installers/linux/build_deb.sh` on a Debian-based system to create a
+`PioneerConverter_1.0.0_amd64.deb` package.  Installing this package places the
+wrapper script in `/usr/local/bin` and the application files under
+`/usr/local/PioneerConverter`.
 ## Output Format
 
 The output files have the following fields with one entry per scan in the *.raw file:

--- a/installers/linux/README.md
+++ b/installers/linux/README.md
@@ -1,0 +1,13 @@
+# Linux Installer
+
+The `build_deb.sh` script creates a Debian package that installs the binaries under `/usr/local/PioneerConverter` and places a wrapper script `pioneerconverter` in `/usr/local/bin`.
+
+## Building
+
+Run the script on a Debian-based system:
+
+```bash
+./build_deb.sh
+```
+
+The resulting `PioneerConverter_1.0.0_amd64.deb` can be installed with `dpkg -i`.

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+APPNAME="PioneerConverter"
+VERSION="1.0.0"
+ARCH="amd64"
+BUILD="debian"
+
+rm -rf "$BUILD"
+mkdir -p "$BUILD/DEBIAN"
+mkdir -p "$BUILD/usr/local/$APPNAME"
+mkdir -p "$BUILD/usr/local/bin"
+
+cp -R ../../dist/PioneerConverter-linux-x64/* "$BUILD/usr/local/$APPNAME/"
+
+cat <<'WRAP' > "$BUILD/usr/local/bin/pioneerconverter"
+#!/bin/bash
+/usr/local/$APPNAME/PioneerConverter "$@"
+WRAP
+chmod +x "$BUILD/usr/local/bin/pioneerconverter"
+
+cat <<CTRL > "$BUILD/DEBIAN/control"
+Package: pioneerconverter
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: $ARCH
+Maintainer: Unknown
+Description: PioneerConverter command line tool
+CTRL
+
+dpkg-deb --build "$BUILD" "${APPNAME}_${VERSION}_${ARCH}.deb"
+
+echo "Package created: ${APPNAME}_${VERSION}_${ARCH}.deb"

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -1,0 +1,14 @@
+# macOS Installer
+
+The `build_pkg.sh` script generates a `.pkg` installer using `pkgbuild`.
+The installer places files under `/usr/local/PioneerConverter` and installs a wrapper script `pioneerconverter` into `/usr/local/bin` so the command is on your `PATH`.
+
+## Building
+
+Run the script on macOS with Xcode command line tools installed:
+
+```bash
+./build_pkg.sh
+```
+
+The result is `PioneerConverter.pkg` in the same directory.

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+APPNAME="PioneerConverter"
+VERSION="1.0.0"
+PKGROOT="pkgroot"
+
+rm -rf "$PKGROOT"
+mkdir -p "$PKGROOT/usr/local/$APPNAME"
+mkdir -p "$PKGROOT/usr/local/bin"
+
+cp -R ../../dist/PioneerConverter-osx-x64/* "$PKGROOT/usr/local/$APPNAME/"
+
+cat <<'WRAP' > "$PKGROOT/usr/local/bin/pioneerconverter"
+#!/bin/bash
+/usr/local/$APPNAME/PioneerConverter "$@"
+WRAP
+chmod +x "$PKGROOT/usr/local/bin/pioneerconverter"
+
+pkgbuild --root "$PKGROOT" \
+  --identifier "com.example.pioneerconverter" \
+  --version "$VERSION" \
+  --install-location "/" "$APPNAME.pkg"
+
+echo "Package created: $APPNAME.pkg"

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -1,0 +1,28 @@
+#define MyAppName "PioneerConverter"
+#define MyAppVersion "1.0.0"
+#define MyAppExeName "PioneerConverter.exe"
+
+[Setup]
+AppId={{9B8088AB-945D-4D65-AB1A-000000000001}}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+DefaultDirName={pf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+OutputBaseFilename=PioneerConverter-Setup
+Compression=lzma
+SolidCompression=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "..\..\dist\PioneerConverter-win-x64\*"; DestDir: "{app}"; Flags: recursesubdirs
+
+[Tasks]
+Name: "addtopath"; Description: "Add application directory to PATH"; Flags: unchecked
+
+[Registry]
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}"; Flags: preservestringtype; Tasks: addtopath
+
+[Icons]
+Name: "{group}\PioneerConverter"; Filename: "{app}\{#MyAppExeName}"

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -1,0 +1,11 @@
+# Windows Installer
+
+The `PioneerConverter.iss` script can be built with [Inno Setup](https://jrsoftware.org/isinfo.php) to produce a GUI installer.
+
+## Building
+
+1. Install Inno Setup.
+2. Open `PioneerConverter.iss` in the Inno Setup Compiler.
+3. Compile the script to generate `PioneerConverter-Setup.exe`.
+
+The installer places the application in `Program Files\\PioneerConverter` and optionally adds the directory to your `PATH`.


### PR DESCRIPTION
## Summary
- add installer generation scripts for Windows, macOS and Linux
- document how to build the installers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68765c85a954832583e1cb02c012a254