### PR TITLE
Fix GitHub action to use artifact v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: installer-${{ matrix.os }}
           path: |

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -8,11 +8,15 @@ OS="$(uname)"
 case "$OS" in
     Linux*)
         echo "Creating Linux .deb package"
-        installers/linux/build_deb.sh
+        pushd installers/linux > /dev/null
+        ./build_deb.sh
+        popd > /dev/null
         ;;
     Darwin*)
         echo "Creating macOS .pkg installer"
-        installers/macos/build_pkg.sh
+        pushd installers/macos > /dev/null
+        ./build_pkg.sh
+        popd > /dev/null
         ;;
     MINGW*|MSYS*|CYGWIN*|Windows_NT)
         echo "Creating Windows installer"


### PR DESCRIPTION
## Summary
- update the workflow to use `actions/upload-artifact@v4`
- fix build_installers.sh to run packaging scripts from their directories

## Testing
- `bash -n build_installers.sh`
- `bash -n installers/linux/build_deb.sh`
- `bash -n installers/macos/build_pkg.sh`
- `dotnet build PioneerConverter.csproj -c Release` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6876949ae3588325bd7c46a7eb967a6c