### PR TITLE
Add macOS entitlements for signed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ Use [Inno Setup](https://jrsoftware.org/isinfo.php) to compile
 
 Run `installers/macos/build_pkg.sh` on a Mac with Xcode command line tools.
 If the environment variables `CODESIGN_IDENTITY` and `PKG_SIGN_IDENTITY` are
-set, the script will codesign the binary and sign the resulting installer.
-It produces `PioneerConverter.pkg` which installs files to
+set, the script will codesign the binary using the entitlements in
+`installers/macos/entitlements.plist` and sign the resulting installer.
+This entitlements file is required for running the signed binaries.
+The script produces `PioneerConverter.pkg` which installs files to
 `/usr/local/PioneerConverter` and symlinks the `pioneerconverter` command to
 `/usr/local/bin`.
 

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -38,6 +38,7 @@ if [[ -n "$CODESIGN_IDENTITY" ]]; then
   while IFS= read -r -d '' file; do
       if file "$file" | grep -q 'Mach-O'; then
         codesign --verbose=4 --force --options runtime --timestamp \
+          --entitlements "$(dirname "$0")/entitlements.plist" \
           --sign "$CODESIGN_IDENTITY" "$file"
       fi
     done < <(find "$PKGROOT/usr/local/$APPNAME" -type f -print0)

--- a/installers/macos/entitlements.plist
+++ b/installers/macos/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add entitlements file for macOS packaging
- use entitlements when codesigning binaries
- document entitlements requirement in macOS packaging instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877034982508325b538a233247a5d44