### PR TITLE
Limit build scripts to current OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,4 +134,5 @@ jobs:
             **/*.deb
             **/*.pkg
             **/*.exe
+            dist/*.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,13 +126,95 @@ jobs:
           done
           
 
-      - name: Upload installer
+
+      - name: Upload binary (linux)
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: installer-${{ matrix.os }}
-          path: |
-            **/*.deb
-            **/*.pkg
-            **/*.exe
-            dist/*.zip
+          name: binary-linux-x64
+          path: dist/PioneerConverter-linux-x64.zip
+
+      - name: Upload installer (linux)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-linux
+          path: installers/linux/PioneerConverter_*_amd64.deb
+
+      - name: Upload binary (windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-win-x64
+          path: dist/PioneerConverter-win-x64.zip
+
+      - name: Upload installer (windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-windows
+          path: installers/windows/PioneerConverter-Setup.exe
+
+      - name: Upload binary (mac arm64)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-mac-arm64
+          path: dist/PioneerConverter-osx-arm64.zip
+
+      - name: Upload binary (mac x64)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-mac-x64
+          path: dist/PioneerConverter-osx-x64.zip
+
+      - name: Upload installer (mac arm64)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-mac-arm64
+          path: installers/macos/PioneerConverter-arm64.pkg
+
+      - name: Upload installer (mac x64)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-mac-x64
+          path: installers/macos/PioneerConverter-x64.pkg
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release view "$tag" >/dev/null 2>&1 || \
+            gh release create "$tag" -t "$tag" -n "Release $tag"
+
+      - name: Upload binaries to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          for file in artifacts/binary-*/*; do
+            gh release upload "$tag" "$file" --clobber
+          done
+
+      - name: Upload installers to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          for file in artifacts/installer-*/*; do
+            gh release upload "$tag" "$file" --clobber
+          done
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ wrapper script in `/usr/local/bin` and the application files under
 Run `./build_installers.sh` to build the binaries and create the installer
 for the current platform.  A GitHub Actions workflow (`build.yml`) executes
 this script on Windows, macOS and Linux whenever a version tag is pushed and
-publishes the resulting installer files **and** the platform-specific
-zip archive of the compiled binaries as build artifacts.
+publishes the installer packages to the project packages section and uploads
+the zipped binaries for each platform as release assets.
 ## Output Format
 
 The output files have the following fields with one entry per scan in the *.raw file:

--- a/README.md
+++ b/README.md
@@ -67,15 +67,10 @@ Convert all files in a directory:
    ./build.sh
    ```
 
-   Or build for a specific platform:
+   Or build only for your current platform:
    ```bash
-   dotnet publish PioneerConverter.csproj -c Release \
-     -r osx-arm64 \
-     -p:PublishSingleFile=false \
-     -p:PublishTrimmed=false \
-     --self-contained true \
-   -o dist/PioneerConverter-osx-arm64
-  ```
+   ./build.sh macos    # or linux / windows
+   ```
 
 ## Building Installers
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ wrapper script in `/usr/local/bin` and the application files under
 Run `./build_installers.sh` to build the binaries and create the installer
 for the current platform.  A GitHub Actions workflow (`build.yml`) executes
 this script on Windows, macOS and Linux whenever a version tag is pushed and
-publishes the resulting installer files as build artifacts.
+publishes the resulting installer files **and** the platform-specific
+zip archive of the compiled binaries as build artifacts.
 ## Output Format
 
 The output files have the following fields with one entry per scan in the *.raw file:

--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,16 @@ esac
 print_step "Creating zip archives"
 cd dist
 for dir in "${BUILT[@]}"; do
-    zip -r "$dir.zip" "$dir"
+    if command -v zip >/dev/null 2>&1; then
+        zip -r "$dir.zip" "$dir"
+    elif command -v 7z >/dev/null 2>&1; then
+        7z a "$dir.zip" "$dir" >/dev/null
+    elif command -v powershell.exe >/dev/null 2>&1; then
+        powershell.exe -Command "Compress-Archive -Path '$dir' -DestinationPath '$dir.zip'" >/dev/null
+    else
+        echo "No zip utility found" >&2
+        exit 1
+    fi
 done
 cd ..
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Function to print step information
 print_step() {
@@ -7,57 +8,87 @@ print_step() {
     echo "-------------------------"
 }
 
+TARGET_OS="${1:-all}"
+
 # Create dist directory if it doesn't exist
 mkdir -p dist
 
-# Build for macOS ARM64 (M1/M2)
-print_step "Building for macOS ARM64"
-dotnet publish PioneerConverter.csproj -c Release \
-  -r osx-arm64 \
-  -p:PublishSingleFile=false \
-  -p:PublishTrimmed=false \
-  --self-contained true \
-  -o dist/PioneerConverter-osx-arm64
+build_macos() {
+    print_step "Building for macOS ARM64"
+    dotnet publish PioneerConverter.csproj -c Release \
+      -r osx-arm64 \
+      -p:PublishSingleFile=false \
+      -p:PublishTrimmed=false \
+      --self-contained true \
+      -o dist/PioneerConverter-osx-arm64
 
-# Build for macOS x64 (Intel)
-print_step "Building for macOS x64"
-dotnet publish PioneerConverter.csproj -c Release \
-  -r osx-x64 \
-  -p:PublishSingleFile=false \
-  -p:PublishTrimmed=false \
-  --self-contained true \
-  -o dist/PioneerConverter-osx-x64
+    print_step "Building for macOS x64"
+    dotnet publish PioneerConverter.csproj -c Release \
+      -r osx-x64 \
+      -p:PublishSingleFile=false \
+      -p:PublishTrimmed=false \
+      --self-contained true \
+      -o dist/PioneerConverter-osx-x64
 
-# Build for Linux x64
-print_step "Building for Linux x64"
-dotnet publish PioneerConverter.csproj -c Release \
-  -r linux-x64 \
-  -p:PublishSingleFile=false \
-  -p:PublishTrimmed=false \
-  --self-contained true \
-  -o dist/PioneerConverter-linux-x64
+    chmod +x dist/PioneerConverter-osx-arm64/PioneerConverter
+    chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
+}
 
-# Build for Windows x64
-print_step "Building for Windows x64"
-dotnet publish PioneerConverter.csproj -c Release \
-  -r win-x64 \
-  -p:PublishSingleFile=false \
-  -p:PublishTrimmed=false \
-  --self-contained true \
-  -o dist/PioneerConverter-win-x64
+build_linux() {
+    print_step "Building for Linux x64"
+    dotnet publish PioneerConverter.csproj -c Release \
+      -r linux-x64 \
+      -p:PublishSingleFile=false \
+      -p:PublishTrimmed=false \
+      --self-contained true \
+      -o dist/PioneerConverter-linux-x64
 
-# Make executables runnable on Unix-like systems
-chmod +x dist/PioneerConverter-osx-arm64/PioneerConverter
-chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
-chmod +x dist/PioneerConverter-linux-x64/PioneerConverter
+    chmod +x dist/PioneerConverter-linux-x64/PioneerConverter
+}
 
-# Create zip archives
+build_windows() {
+    print_step "Building for Windows x64"
+    dotnet publish PioneerConverter.csproj -c Release \
+      -r win-x64 \
+      -p:PublishSingleFile=false \
+      -p:PublishTrimmed=false \
+      --self-contained true \
+      -o dist/PioneerConverter-win-x64
+}
+
+BUILT=()
+
+case "$TARGET_OS" in
+    macos)
+        build_macos
+        BUILT+=(PioneerConverter-osx-arm64 PioneerConverter-osx-x64)
+        ;;
+    linux)
+        build_linux
+        BUILT+=(PioneerConverter-linux-x64)
+        ;;
+    windows)
+        build_windows
+        BUILT+=(PioneerConverter-win-x64)
+        ;;
+    all)
+        build_macos
+        build_linux
+        build_windows
+        BUILT+=(PioneerConverter-osx-arm64 PioneerConverter-osx-x64 \
+               PioneerConverter-linux-x64 PioneerConverter-win-x64)
+        ;;
+    *)
+        echo "Unknown target OS: $TARGET_OS" >&2
+        exit 1
+        ;;
+esac
+
 print_step "Creating zip archives"
 cd dist
-zip -r PioneerConverter-osx-arm64.zip PioneerConverter-osx-arm64
-zip -r PioneerConverter-osx-x64.zip PioneerConverter-osx-x64
-zip -r PioneerConverter-linux-x64.zip PioneerConverter-linux-x64
-zip -r PioneerConverter-win-x64.zip PioneerConverter-win-x64
+for dir in "${BUILT[@]}"; do
+    zip -r "$dir.zip" "$dir"
+done
 cd ..
 
 echo "Build complete! Check the dist directory for the output files."

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -1,31 +1,43 @@
 #!/bin/bash
 set -e
 
-# Build cross-platform binaries
-./build.sh
-
 OS="$(uname)"
 case "$OS" in
     Linux*)
+        TARGET=linux
+        ;;
+    Darwin*)
+        TARGET=macos
+        ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        TARGET=windows
+        ;;
+    *)
+        echo "Unsupported OS: $OS" >&2
+        exit 1
+        ;;
+esac
+
+# Build binaries only for the current platform
+./build.sh "$TARGET"
+
+case "$TARGET" in
+    linux)
         echo "Creating Linux .deb package"
         pushd installers/linux > /dev/null
         ./build_deb.sh
         popd > /dev/null
         ;;
-    Darwin*)
+    macos)
         echo "Creating macOS .pkg installers"
         pushd installers/macos > /dev/null
         PKG_ARCH=arm64 ./build_pkg.sh
         PKG_ARCH=x64 ./build_pkg.sh
         popd > /dev/null
         ;;
-    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    windows)
         echo "Creating Windows installer"
         iscc installers/windows/PioneerConverter.iss
-        ;;
-    *)
-        echo "Unsupported OS: $OS" >&2
-        exit 1
         ;;
 esac
 

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -37,7 +37,12 @@ case "$TARGET" in
         ;;
     windows)
         echo "Creating Windows installer"
-        iscc installers/windows/PioneerConverter.iss
+        pushd installers/windows > /dev/null
+        iscc PioneerConverter.iss
+        if [ -f Output/PioneerConverter-Setup.exe ]; then
+            mv Output/PioneerConverter-Setup.exe PioneerConverter-Setup.exe
+        fi
+        popd > /dev/null
         ;;
 esac
 


### PR DESCRIPTION
## Summary
- add target OS argument to `build.sh`
- invoke `build.sh` with the current OS inside `build_installers.sh`
- update README to show new build instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877099e2c2483259b662540fda93938