### PR TITLE
Add checkout to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,8 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts


### PR DESCRIPTION
## Summary
- fix release workflow by checking out repo before using gh

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877c56fc4188325b1aeb9f2c95dbd12