### PR TITLE
Update release asset naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,8 @@ jobs:
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           for file in artifacts/binary-*/*; do
-            gh release upload "$tag" "$file" --clobber
+            name="BINARY-$(basename "$file")"
+            gh release upload "$tag" "$file" --clobber --name "$name"
           done
 
       - name: Upload installers to release
@@ -217,6 +218,7 @@ jobs:
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           for file in artifacts/installer-*/*; do
-            gh release upload "$tag" "$file" --clobber
+            name="INSTALLER-$(basename "$file")"
+            gh release upload "$tag" "$file" --clobber --name "$name"
           done
 


### PR DESCRIPTION
## Summary
- rename uploaded GitHub release artifacts so that binaries and installers are clearly grouped

## Testing
- `grep -n "BINARY-" -n -n .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_6877cbc301608325aecad35fac27d9ff