### PR TITLE
Update release asset naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,8 @@ jobs:
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           for file in artifacts/binary-*/*; do
-            gh release upload "$tag" "$file" --clobber
+            name="Binary-$(basename "$file")"
+            gh release upload "$tag" "$file#$name" --clobber
           done
 
       - name: Upload installers to release
@@ -217,6 +218,17 @@ jobs:
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           for file in artifacts/installer-*/*; do
-            gh release upload "$tag" "$file" --clobber
+            base="$(basename "$file")"
+            dir="$(basename "$(dirname "$file")")"
+            case "$dir" in
+              installer-mac-arm64)
+                base="${base/-arm64/-osx-arm64}"
+                ;;
+              installer-mac-x64)
+                base="${base/-x64/-osx-x64}"
+                ;;
+            esac
+            name="Installer-$base"
+            gh release upload "$tag" "$file#$name" --clobber
           done
 


### PR DESCRIPTION
## Summary
- rename uploaded GitHub release artifacts so binaries and installers are clearly grouped
- use `file#name` syntax because the `--name` flag isn't supported
- add `osx` to macOS installer assets and switch prefixes to `Binary-` and `Installer-`

## Testing
- `grep -n "Binary-" .github/workflows/build.yml`
- `grep -n "Installer-" .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_6877cbc301608325aecad35fac27d9ff