### PR TITLE
Rename installers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-linux
-          path: installers/linux/PioneerConverter_*_amd64.deb
+          path: installers/linux/PioneerConverter-linux_*_amd64.deb
 
       - name: Upload binary (windows)
         if: matrix.os == 'windows-latest'
@@ -153,7 +153,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-windows
-          path: installers/windows/PioneerConverter-Setup.exe
+          path: installers/windows/PioneerConverter-win-Setup.exe
 
       - name: Upload binary (mac arm64)
         if: matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the command is available system&#8209;wide.
 
 ### Using the installers
 
-- **Windows**: run `PioneerConverter-Setup.exe`.  The program is
+- **Windows**: run `PioneerConverter-win-Setup.exe`.  The program is
   installed under *Program&nbsp;Files* and a `PioneerConverter` command
   is optionally added to your `PATH`.
 - **macOS**: open `PioneerConverter.pkg`.  This installs the files in
@@ -22,7 +22,7 @@ the command is available system&#8209;wide.
   to `/usr/local/bin`.
 - **Linux**: install the `.deb` package, e.g.
   ```bash
-  sudo dpkg -i PioneerConverter_*.deb
+  sudo dpkg -i PioneerConverter-linux_*.deb
   ```
   This also installs the wrapper command to `/usr/local/bin`.
 

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -39,8 +39,8 @@ case "$TARGET" in
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
         iscc PioneerConverter.iss
-        if [ -f Output/PioneerConverter-Setup.exe ]; then
-            mv Output/PioneerConverter-Setup.exe PioneerConverter-Setup.exe
+        if [ -f Output/PioneerConverter-win-Setup.exe ]; then
+            mv Output/PioneerConverter-win-Setup.exe PioneerConverter-win-Setup.exe
         fi
         popd > /dev/null
         ;;

--- a/installers/linux/README.md
+++ b/installers/linux/README.md
@@ -10,4 +10,4 @@ Run the script on a Debian-based system:
 ./build_deb.sh
 ```
 
-The resulting `PioneerConverter_1.0.0_amd64.deb` can be installed with `dpkg -i`.
+The resulting `PioneerConverter-linux_1.0.0_amd64.deb` can be installed with `dpkg -i`.

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -29,6 +29,6 @@ Maintainer: Unknown
 Description: PioneerConverter command line tool
 CTRL
 
-dpkg-deb --build "$BUILD" "${APPNAME}_${VERSION}_${ARCH}.deb"
+dpkg-deb --build "$BUILD" "${APPNAME}-linux_${VERSION}_${ARCH}.deb"
 
-echo "Package created: ${APPNAME}_${VERSION}_${ARCH}.deb"
+echo "Package created: ${APPNAME}-linux_${VERSION}_${ARCH}.deb"

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -8,7 +8,7 @@ AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 DefaultDirName={pf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
-OutputBaseFilename=PioneerConverter-Setup
+OutputBaseFilename=PioneerConverter-win-Setup
 Compression=lzma
 SolidCompression=yes
 

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -6,6 +6,6 @@ The `PioneerConverter.iss` script can be built with [Inno Setup](https://jrsoftw
 
 1. Install Inno Setup.
 2. Open `PioneerConverter.iss` in the Inno Setup Compiler.
-3. Compile the script to generate `PioneerConverter-Setup.exe`.
+3. Compile the script to generate `PioneerConverter-win-Setup.exe`.
 
 The installer places the application in `Program Files\\PioneerConverter` and optionally adds the directory to your `PATH`.


### PR DESCRIPTION
## Summary
- rename Windows installer to `PioneerConverter-win-Setup.exe`
- rename Debian package to `PioneerConverter-linux_<version>_<arch>.deb`
- update docs, build script and workflow for new names

## Testing
- `./build.sh linux` *(fails: dotnet not found)*
- `./build_installers.sh linux` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d9279d5083259ed74a51e231a2ff