### PR TITLE
Include version in installer filenames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-windows
-          path: installers/windows/PioneerConverter-win-Setup.exe
+          path: installers/windows/PioneerConverter-win-*-Setup.exe
 
       - name: Upload binary (mac arm64)
         if: matrix.os == 'macos-latest'
@@ -174,14 +174,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-mac-arm64
-          path: installers/macos/PioneerConverter-arm64.pkg
+          path: installers/macos/PioneerConverter-arm64-*.pkg
 
       - name: Upload installer (mac x64)
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: installer-mac-x64
-          path: installers/macos/PioneerConverter-x64.pkg
+          path: installers/macos/PioneerConverter-x64-*.pkg
 
   release:
     runs-on: ubuntu-latest

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -18,6 +18,12 @@ case "$OS" in
         ;;
 esac
 
+# Determine version from env or git tag
+VERSION="${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")}"
+# strip leading v if present
+VERSION="${VERSION#v}"
+export VERSION
+
 # Build binaries only for the current platform
 ./build.sh "$TARGET"
 
@@ -38,9 +44,11 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc PioneerConverter.iss
-        if [ -f Output/PioneerConverter-win-Setup.exe ]; then
-            mv Output/PioneerConverter-win-Setup.exe PioneerConverter-win-Setup.exe
+        iscc /DMyAppVersion="$VERSION" PioneerConverter.iss
+        if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
+            mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
+        elif [ -f Output/PioneerConverter-win-Setup.exe ]; then
+            mv Output/PioneerConverter-win-Setup.exe "PioneerConverter-win-${VERSION}-Setup.exe"
         fi
         popd > /dev/null
         ;;

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -2,7 +2,7 @@
 set -e
 
 APPNAME="PioneerConverter"
-VERSION="1.0.0"
+VERSION="${VERSION:-1.0.0}"
 ARCH="amd64"
 BUILD="debian"
 

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -2,18 +2,18 @@
 set -e
 
 APPNAME="PioneerConverter"
-VERSION="1.0.0"
+VERSION="${VERSION:-1.0.0}"
 PKGROOT="pkgroot"
 PKG_ARCH="${PKG_ARCH:-$(uname -m)}"
 
 case "$PKG_ARCH" in
   arm64|aarch64)
     DIST="../../dist/${APPNAME}-osx-arm64"
-    PKGFILE="${APPNAME}-arm64.pkg"
+    PKGFILE="${APPNAME}-arm64-${VERSION}.pkg"
     ;;
   x64|x86_64)
     DIST="../../dist/${APPNAME}-osx-x64"
-    PKGFILE="${APPNAME}-x64.pkg"
+    PKGFILE="${APPNAME}-x64-${VERSION}.pkg"
     ;;
   *)
     echo "Unsupported architecture: $PKG_ARCH" >&2

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -1,5 +1,7 @@
 #define MyAppName "PioneerConverter"
+#ifndef MyAppVersion
 #define MyAppVersion "1.0.0"
+#endif
 #define MyAppExeName "PioneerConverter.exe"
 
 [Setup]
@@ -8,7 +10,7 @@ AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 DefaultDirName={pf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
-OutputBaseFilename=PioneerConverter-win-Setup
+OutputBaseFilename=PioneerConverter-win-{#MyAppVersion}-Setup
 Compression=lzma
 SolidCompression=yes
 


### PR DESCRIPTION
## Summary
- detect VERSION from git tag
- use VERSION in Windows, macOS, and Linux installer scripts
- update workflow to handle versioned installer names

## Testing
- `bash -n build_installers.sh`
- `bash -n installers/linux/build_deb.sh`
- `bash -n installers/macos/build_pkg.sh`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddccbb908325960e9c3f0798b202