### PR TITLE
Include version in installer filenames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-windows
-          path: installers/windows/PioneerConverter-win-Setup.exe
+          path: installers/windows/PioneerConverter-win-*-Setup.exe
 
       - name: Upload binary (mac arm64)
         if: matrix.os == 'macos-latest'
@@ -174,14 +174,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-mac-arm64
-          path: installers/macos/PioneerConverter-arm64.pkg
+          path: installers/macos/PioneerConverter-arm64-*.pkg
 
       - name: Upload installer (mac x64)
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: installer-mac-x64
-          path: installers/macos/PioneerConverter-x64.pkg
+          path: installers/macos/PioneerConverter-x64-*.pkg
 
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ the command is available system&#8209;wide.
 
 ### Using the installers
 
-- **Windows**: run `PioneerConverter-win-Setup.exe`.  The program is
+- **Windows**: run `PioneerConverter-win-1.2.3-Setup.exe` (replace `1.2.3`
+  with the release tag).  The program is
   installed under *Program&nbsp;Files* and a `PioneerConverter` command
   is optionally added to your `PATH`.
-- **macOS**: open `PioneerConverter.pkg`.  This installs the files in
+- **macOS**: open `PioneerConverter-<arch>-1.2.3.pkg` (replace `1.2.3` with the
+  release tag).  This installs the files in
   `/usr/local/PioneerConverter` and links the `PioneerConverter` command
   to `/usr/local/bin`.
 - **Linux**: install the `.deb` package, e.g.
   ```bash
-  sudo dpkg -i PioneerConverter-linux_*.deb
+  sudo dpkg -i PioneerConverter-linux_1.2.3_amd64.deb
+  # replace 1.2.3 with the release tag
   ```
   This also installs the wrapper command to `/usr/local/bin`.
 

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,7 +45,7 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc "PioneerConverter.iss" /DMyAppVersion=$VERSION
+        iscc "PioneerConverter.iss"
         if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
             mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,8 +45,7 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        echo $VERSION
-        iscc PioneerConverter.iss /DMyAppVersion=${VERSION}
+        iscc "PioneerConverter.iss" /DMyAppVersion=$VERSION
         if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
             mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,7 +45,7 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc PioneerConverter.iss /DMyAppVersion=$VERSION
+        iscc PioneerConverter.iss
         if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
             mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,7 +45,7 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc /DMyAppVersion=$VERSION PioneerConverter.iss
+        iscc "/DMyAppVersion=$VERSION" "PioneerConverter.iss"
         if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
             mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,7 +45,8 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc PioneerConverter.iss
+        echo $VERSION
+        iscc PioneerConverter.iss /DMyAppVersion=${VERSION}
         if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
             mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,7 +45,7 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc "/DMyAppVersion=$VERSION" "PioneerConverter.iss"
+        iscc PioneerConverter.iss /DMyAppVersion=$VERSION
         if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
             mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -18,6 +18,13 @@ case "$OS" in
         ;;
 esac
 
+# Determine version from env or latest Git tag
+VERSION="${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")}"
+# Remove a leading 'v' and any trailing CR/LF
+VERSION="${VERSION#v}"
+VERSION="$(echo "$VERSION" | tr -d '\r\n')"
+export VERSION
+
 # Build binaries only for the current platform
 ./build.sh "$TARGET"
 
@@ -38,9 +45,11 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        iscc PioneerConverter.iss
-        if [ -f Output/PioneerConverter-win-Setup.exe ]; then
-            mv Output/PioneerConverter-win-Setup.exe PioneerConverter-win-Setup.exe
+        iscc /DMyAppVersion=$VERSION PioneerConverter.iss
+        if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
+            mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
+        elif [ -f Output/PioneerConverter-win-Setup.exe ]; then
+            mv Output/PioneerConverter-win-Setup.exe "PioneerConverter-win-${VERSION}-Setup.exe"
         fi
         popd > /dev/null
         ;;

--- a/installers/linux/README.md
+++ b/installers/linux/README.md
@@ -10,4 +10,5 @@ Run the script on a Debian-based system:
 ./build_deb.sh
 ```
 
-The resulting `PioneerConverter-linux_1.0.0_amd64.deb` can be installed with `dpkg -i`.
+The resulting `PioneerConverter-linux_<version>_amd64.deb` can be installed
+with `dpkg -i` where `<version>` is the release tag.

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -2,7 +2,7 @@
 set -e
 
 APPNAME="PioneerConverter"
-VERSION="1.0.0"
+VERSION="${VERSION:-1.0.0}"
 ARCH="amd64"
 BUILD="debian"
 

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -11,4 +11,6 @@ Run the script on macOS with Xcode command line tools installed:
 ./build_pkg.sh
 ```
 
-The result is `PioneerConverter.pkg` in the same directory.
+The result is either `PioneerConverter-arm64-<version>.pkg` or
+`PioneerConverter-x64-<version>.pkg` depending on the architecture.
+Replace `<version>` with the release tag.

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -2,18 +2,18 @@
 set -e
 
 APPNAME="PioneerConverter"
-VERSION="1.0.0"
+VERSION="${VERSION:-1.0.0}"
 PKGROOT="pkgroot"
 PKG_ARCH="${PKG_ARCH:-$(uname -m)}"
 
 case "$PKG_ARCH" in
   arm64|aarch64)
     DIST="../../dist/${APPNAME}-osx-arm64"
-    PKGFILE="${APPNAME}-arm64.pkg"
+    PKGFILE="${APPNAME}-arm64-${VERSION}.pkg"
     ;;
   x64|x86_64)
     DIST="../../dist/${APPNAME}-osx-x64"
-    PKGFILE="${APPNAME}-x64.pkg"
+    PKGFILE="${APPNAME}-x64-${VERSION}.pkg"
     ;;
   *)
     echo "Unsupported architecture: $PKG_ARCH" >&2

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -1,5 +1,7 @@
 #define MyAppName "PioneerConverter"
+#ifndef MyAppVersion
 #define MyAppVersion "1.0.0"
+#endif
 #define MyAppExeName "PioneerConverter.exe"
 
 [Setup]
@@ -8,7 +10,7 @@ AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 DefaultDirName={pf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
-OutputBaseFilename=PioneerConverter-win-Setup
+OutputBaseFilename=PioneerConverter-win-{#MyAppVersion}-Setup
 Compression=lzma
 SolidCompression=yes
 

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -5,7 +5,9 @@ The `PioneerConverter.iss` script can be built with [Inno Setup](https://jrsoftw
 ## Building
 
 1. Install Inno Setup.
-2. Open `PioneerConverter.iss` in the Inno Setup Compiler.
-3. Compile the script to generate `PioneerConverter-win-Setup.exe`.
+2. Open `PioneerConverter.iss` in the Inno Setup Compiler or run
+   `iscc /DMyAppVersion=<version> PioneerConverter.iss` from the command line,
+   replacing `<version>` with the release tag.
+3. The output is `PioneerConverter-win-<version>-Setup.exe`.
 
 The installer places the application in `Program Files\\PioneerConverter` and optionally adds the directory to your `PATH`.

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -6,7 +6,7 @@ The `PioneerConverter.iss` script can be built with [Inno Setup](https://jrsoftw
 
 1. Install Inno Setup.
 2. Open `PioneerConverter.iss` in the Inno Setup Compiler or run
-   `iscc /DMyAppVersion=<version> PioneerConverter.iss` from the command line,
+   `iscc "/DMyAppVersion=<version>" "PioneerConverter.iss"` from the command line,
    replacing `<version>` with the release tag.
 3. The output is `PioneerConverter-win-<version>-Setup.exe`.
 


### PR DESCRIPTION
## Summary
- strip newline when reading git tag for VERSION
- quote iscc arguments for Windows build
- document versioned installer filenames
- sanitize CR/LF in VERSION and fix Windows iscc command
- document CLI build command for Windows installer

## Testing
- `bash -n build_installers.sh`
- `bash -n installers/linux/build_deb.sh`
- `bash -n installers/macos/build_pkg.sh`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddccbb908325960e9c3f0798b202