### PR TITLE
Fix Windows installer naming

### DIFF
--- a/build_installers.sh
+++ b/build_installers.sh
@@ -46,8 +46,9 @@ case "$TARGET" in
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
         iscc "PioneerConverter.iss"
-        if [ -f Output/PioneerConverter-win-${VERSION}-Setup.exe ]; then
-            mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
+        output_file="$(ls Output/PioneerConverter-win-*-Setup.exe 2>/dev/null | head -n1)"
+        if [ -n "$output_file" ]; then
+            mv "$output_file" "PioneerConverter-win-${VERSION}-Setup.exe"
         elif [ -f Output/PioneerConverter-win-Setup.exe ]; then
             mv Output/PioneerConverter-win-Setup.exe "PioneerConverter-win-${VERSION}-Setup.exe"
         fi

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -8,11 +8,12 @@
 AppId={{9B8088AB-945D-4D65-AB1A-000000000001}}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
-DefaultDirName={pf}\{#MyAppName}
+DefaultDirName={autopf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 OutputBaseFilename=PioneerConverter-win-{#MyAppVersion}-Setup
 Compression=lzma
 SolidCompression=yes
+PrivilegesRequired=admin
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -24,7 +25,7 @@ Source: "..\..\dist\PioneerConverter-win-x64\*"; DestDir: "{app}"; Flags: recurs
 Name: "addtopath"; Description: "Add application directory to PATH"; Flags: unchecked
 
 [Registry]
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}"; Flags: preservestringtype; Tasks: addtopath
+Root: HKLM; Subkey: "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Flags: preservestringtype; Tasks: addtopath
 
 [Icons]
 Name: "{group}\PioneerConverter"; Filename: "{app}\{#MyAppExeName}"

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -6,8 +6,12 @@ The `PioneerConverter.iss` script can be built with [Inno Setup](https://jrsoftw
 
 1. Install Inno Setup.
 2. Open `PioneerConverter.iss` in the Inno Setup Compiler or run
-   `iscc "/DMyAppVersion=<version>" "PioneerConverter.iss"` from the command line,
-   replacing `<version>` with the release tag.
-3. The output is `PioneerConverter-win-<version>-Setup.exe`.
+   `iscc "PioneerConverter.iss"` from the command line.
+3. Rename the produced file in the `Output` directory to
+   `PioneerConverter-win-<version>-Setup.exe`, replacing `<version>` with the
+   release tag.
 
-The installer places the application in `Program Files\\PioneerConverter` and optionally adds the directory to your `PATH`.
+The installer places the application in `Program Files\\PioneerConverter` and
+optionally adds the directory to your system `PATH`.  Because both of these
+actions modify system-wide locations, you must run the installer with
+administrator privileges.


### PR DESCRIPTION
## Summary
- rename Windows installer after building so the version tag is kept
- update Windows README with new instructions
- fix deprecation warning for `{pf}` constant
- write PATH changes to HKLM and explain that admin rights are needed

## Testing
- `bash -n build_installers.sh`


------
https://chatgpt.com/codex/tasks/task_e_6877ef778cbc8325a34a3aac6bd191c4