### PR TITLE
Versioned zip outputs and source archives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: binary-linux-x64
-          path: dist/PioneerConverter-linux-x64.zip
+          path: dist/PioneerConverter-linux-x64-*.zip
 
       - name: Upload installer (linux)
         if: matrix.os == 'ubuntu-latest'
@@ -146,7 +146,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: binary-win-x64
-          path: dist/PioneerConverter-win-x64.zip
+          path: dist/PioneerConverter-win-x64-*.zip
 
       - name: Upload installer (windows)
         if: matrix.os == 'windows-latest'
@@ -160,14 +160,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: binary-mac-arm64
-          path: dist/PioneerConverter-osx-arm64.zip
+          path: dist/PioneerConverter-osx-arm64-*.zip
 
       - name: Upload binary (mac x64)
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: binary-mac-x64
-          path: dist/PioneerConverter-osx-x64.zip
+          path: dist/PioneerConverter-osx-x64-*.zip
 
       - name: Upload installer (mac arm64)
         if: matrix.os == 'macos-latest'
@@ -193,6 +193,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+
+      - name: Create source archives
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          git archive --format=zip --output "PioneerConverter-${tag}-source.zip" "$tag"
+          git archive --format=tar.gz --output "PioneerConverter-${tag}-source.tar.gz" "$tag"
 
       - name: Create GitHub release
         env:
@@ -231,4 +237,14 @@ jobs:
             name="Installer-$base"
             gh release upload "$tag" "$file#$name" --clobber
           done
+
+      - name: Upload sources to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release upload "$tag" \
+            "PioneerConverter-${tag}-source.zip#Source-PioneerConverter-${tag}.zip" \
+            "PioneerConverter-${tag}-source.tar.gz#Source-PioneerConverter-${tag}.tar.gz" \
+            --clobber
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ PioneerConverter <input path>
 
 If you prefer a portable copy download one of the zip files:
 
-- macOS M1/M2 (ARM64): `PioneerConverter-osx-arm64.zip`
-- macOS Intel (x64): `PioneerConverter-osx-x64.zip`
-- Linux (x64): `PioneerConverter-linux-x64.zip`
-- Windows (x64): `PioneerConverter-win-x64.zip`
+- macOS M1/M2 (ARM64): `PioneerConverter-osx-arm64-1.2.3.zip`
+- macOS Intel (x64): `PioneerConverter-osx-x64-1.2.3.zip`
+- Linux (x64): `PioneerConverter-linux-x64-1.2.3.zip`
+- Windows (x64): `PioneerConverter-win-x64-1.2.3.zip`
+
+Source code archives are also provided as
+`PioneerConverter-1.2.3-source.zip` and
+`PioneerConverter-1.2.3-source.tar.gz`.
+(Replace `1.2.3` with the release tag.)
 
 Extract the archive and run the `PioneerConverter` executable from the
 extracted directory.  On macOS and Linux you may need to make the file

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,11 @@ print_step() {
 
 TARGET_OS="${1:-all}"
 
+# Determine version from env or latest Git tag
+VERSION="${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")}"
+VERSION="${VERSION#v}"
+VERSION="$(echo "$VERSION" | tr -d '\n')"
+
 # Create dist directory if it doesn't exist
 mkdir -p dist
 
@@ -88,11 +93,11 @@ print_step "Creating zip archives"
 cd dist
 for dir in "${BUILT[@]}"; do
     if command -v zip >/dev/null 2>&1; then
-        zip -r "$dir.zip" "$dir"
+        zip -r "${dir}-${VERSION}.zip" "$dir"
     elif command -v 7z >/dev/null 2>&1; then
-        7z a "$dir.zip" "$dir" >/dev/null
+        7z a "${dir}-${VERSION}.zip" "$dir" >/dev/null
     elif command -v powershell.exe >/dev/null 2>&1; then
-        powershell.exe -Command "Compress-Archive -Path '$dir' -DestinationPath '$dir.zip'" >/dev/null
+        powershell.exe -Command "Compress-Archive -Path '$dir' -DestinationPath '${dir}-${VERSION}.zip'" >/dev/null
     else
         echo "No zip utility found" >&2
         exit 1


### PR DESCRIPTION
## Summary
- include build version in zip archive names
- document versioned zips in README
- upload binaries using wildcard paths
- generate and upload source archives in release workflow

## Testing
- `dotnet build PioneerConverter.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f7e02cd083258acf5e1a863becc6