### PR TITLE
Sign and notarize macOS binaries in zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
           PKG_SIGN_IDENTITY: ${{ secrets.PKG_SIGN_IDENTITY }}
 
-      - name: Notarize macOS package
+      - name: Notarize macOS artifacts
         if: matrix.os == 'macos-latest'
         env:
           AC_USERNAME: ${{ secrets.NOTARIZE_APPLE_ID }}
@@ -104,15 +104,15 @@ jobs:
             --apple-id "$AC_USERNAME" \
             --team-id "$TEAM_ID" \
             --password "$AC_PASSWORD"
-          for pkg in installers/macos/PioneerConverter-*.pkg; do
-            echo "Submitting $pkg"
-            result=$(xcrun notarytool submit "$pkg" \
+          for file in installers/macos/PioneerConverter-*.pkg dist/PioneerConverter-osx-*.zip; do
+            echo "Submitting $file"
+            result=$(xcrun notarytool submit "$file" \
               --keychain-profile notary-profile --wait --output-format json)
             echo "$result"
             status=$(echo "$result" | grep -o '"status" *: *"[^"]*"' | head -n1 | sed 's/.*"status" *: *"\([^"]*\)"/\1/')
             subid=$(echo "$result" | grep -o '"id" *: *"[^"]*"' | head -n1 | sed 's/.*"id" *: *"\([^"]*\)"/\1/')
             if [ "$status" != "Accepted" ]; then
-              echo "Notarization failed for $pkg with status $status"
+              echo "Notarization failed for $file with status $status"
               xcrun notarytool log "$subid" --keychain-profile notary-profile
               exit 1
             fi
@@ -121,8 +121,8 @@ jobs:
       - name: Staple notarization ticket
         if: matrix.os == 'macos-latest'
         run: |
-          for pkg in installers/macos/PioneerConverter-*.pkg; do
-            xcrun stapler staple "$pkg"
+          for file in installers/macos/PioneerConverter-*.pkg dist/PioneerConverter-osx-*.zip; do
+            xcrun stapler staple "$file"
           done
           
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,8 +121,9 @@ jobs:
       - name: Staple notarization ticket
         if: matrix.os == 'macos-latest'
         run: |
-          for file in installers/macos/PioneerConverter-*.pkg dist/PioneerConverter-osx-*.zip; do
-            xcrun stapler staple "$file"
+          # Stapler can't operate on zip archives, so only staple pkg installers
+          for pkg in installers/macos/PioneerConverter-*.pkg; do
+            xcrun stapler staple "$pkg"
           done
           
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,9 @@ jobs:
             --apple-id "$AC_USERNAME" \
             --team-id "$TEAM_ID" \
             --password "$AC_PASSWORD"
-          for file in installers/macos/PioneerConverter-*.pkg dist/PioneerConverter-osx-*.zip; do
+          for file in installers/macos/PioneerConverter-*.pkg \
+                     dist/PioneerConverter-osx-arm64/PioneerConverter \
+                     dist/PioneerConverter-osx-x64/PioneerConverter; do
             echo "Submitting $file"
             result=$(xcrun notarytool submit "$file" \
               --keychain-profile notary-profile --wait --output-format json)
@@ -125,11 +127,16 @@ jobs:
             xcrun stapler staple "$pkg"
           done
 
+          for bin in dist/PioneerConverter-osx-arm64/PioneerConverter dist/PioneerConverter-osx-x64/PioneerConverter; do
+            if [ -f "$bin" ]; then
+              xcrun stapler staple "$bin"
+            fi
+          done
+
           for zip in dist/PioneerConverter-osx-*.zip; do
             arch=$(echo "$zip" | sed -E 's/.*osx-([^-]+)-.*\.zip/\1/')
             dir="dist/PioneerConverter-osx-$arch"
             if [ -f "$dir/PioneerConverter" ]; then
-              xcrun stapler staple "$dir/PioneerConverter"
               rm -f "$zip"
               (cd dist && zip -r "$(basename "$zip")" "$(basename "$dir")")
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
             --team-id "$TEAM_ID" \
             --password "$AC_PASSWORD"
           for file in installers/macos/PioneerConverter-*.pkg \
-                     dist/PioneerConverter-osx-arm64-*.zip \
-                     dist/PioneerConverter-osx-x64-*.zip; do
+                     dist/PioneerConverter-osx-arm64/PioneerConverter \
+                     dist/PioneerConverter-osx-x64/PioneerConverter; do
             echo "Submitting $file"
             result=$(xcrun notarytool submit "$file" \
               --keychain-profile notary-profile --wait --output-format json)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
             --team-id "$TEAM_ID" \
             --password "$AC_PASSWORD"
           for file in installers/macos/PioneerConverter-*.pkg \
-                     dist/PioneerConverter-osx-arm64/PioneerConverter \
-                     dist/PioneerConverter-osx-x64/PioneerConverter; do
+                     dist/PioneerConverter-osx-arm64-*.zip \
+                     dist/PioneerConverter-osx-x64-*.zip; do
             echo "Submitting $file"
             result=$(xcrun notarytool submit "$file" \
               --keychain-profile notary-profile --wait --output-format json)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,18 @@ jobs:
       - name: Staple notarization ticket
         if: matrix.os == 'macos-latest'
         run: |
-          # Stapler can't operate on zip archives, so only staple pkg installers
           for pkg in installers/macos/PioneerConverter-*.pkg; do
             xcrun stapler staple "$pkg"
+          done
+
+          for zip in dist/PioneerConverter-osx-*.zip; do
+            arch=$(echo "$zip" | sed -E 's/.*osx-([^-]+)-.*\.zip/\1/')
+            dir="dist/PioneerConverter-osx-$arch"
+            if [ -f "$dir/PioneerConverter" ]; then
+              xcrun stapler staple "$dir/PioneerConverter"
+              rm -f "$zip"
+              (cd dist && zip -r "$(basename "$zip")" "$(basename "$dir")")
+            fi
           done
           
 

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,15 @@ build_macos() {
 
     chmod +x dist/PioneerConverter-osx-arm64/PioneerConverter
     chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
+
+    if [[ -n "$CODESIGN_IDENTITY" ]]; then
+        print_step "Codesigning macOS binaries"
+        for file in dist/PioneerConverter-osx-arm64/PioneerConverter dist/PioneerConverter-osx-x64/PioneerConverter; do
+            codesign --verbose=4 --force --options runtime --timestamp \
+                --entitlements installers/macos/entitlements.plist \
+                --sign "$CODESIGN_IDENTITY" "$file"
+        done
+    fi
 }
 
 build_linux() {

--- a/build.sh
+++ b/build.sh
@@ -39,14 +39,12 @@ build_macos() {
     chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
 
     if [[ -n "$CODESIGN_IDENTITY" ]]; then
-        print_step "Codesigning macOS binaries"
+        print_step "Codesigning macOS files"
         for dir in dist/PioneerConverter-osx-arm64 dist/PioneerConverter-osx-x64; do
-            find "$dir" -type f | while read -r file; do
-                if file "$file" | grep -q 'Mach-O'; then
-                    codesign --verbose=4 --force --options runtime --timestamp \
-                        --entitlements installers/macos/entitlements.plist \
-                        --sign "$CODESIGN_IDENTITY" "$file"
-                fi
+            find "$dir" -type f -print0 | while IFS= read -r -d '' file; do
+                codesign --verbose=4 --force --options runtime --timestamp \
+                    --entitlements installers/macos/entitlements.plist \
+                    --sign "$CODESIGN_IDENTITY" "$file"
             done
         done
     fi

--- a/build.sh
+++ b/build.sh
@@ -39,12 +39,14 @@ build_macos() {
     chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
 
     if [[ -n "$CODESIGN_IDENTITY" ]]; then
-        print_step "Codesigning macOS files"
+        print_step "Codesigning macOS binaries"
         for dir in dist/PioneerConverter-osx-arm64 dist/PioneerConverter-osx-x64; do
             find "$dir" -type f -print0 | while IFS= read -r -d '' file; do
-                codesign --verbose=4 --force --options runtime --timestamp \
-                    --entitlements installers/macos/entitlements.plist \
-                    --sign "$CODESIGN_IDENTITY" "$file"
+                if file "$file" | grep -q 'Mach-O'; then
+                    codesign --verbose=4 --force --options runtime --timestamp \
+                        --entitlements installers/macos/entitlements.plist \
+                        --sign "$CODESIGN_IDENTITY" "$file"
+                fi
             done
         done
     fi

--- a/build.sh
+++ b/build.sh
@@ -40,10 +40,14 @@ build_macos() {
 
     if [[ -n "$CODESIGN_IDENTITY" ]]; then
         print_step "Codesigning macOS binaries"
-        for file in dist/PioneerConverter-osx-arm64/PioneerConverter dist/PioneerConverter-osx-x64/PioneerConverter; do
-            codesign --verbose=4 --force --options runtime --timestamp \
-                --entitlements installers/macos/entitlements.plist \
-                --sign "$CODESIGN_IDENTITY" "$file"
+        for dir in dist/PioneerConverter-osx-arm64 dist/PioneerConverter-osx-x64; do
+            find "$dir" -type f | while read -r file; do
+                if file "$file" | grep -q 'Mach-O'; then
+                    codesign --verbose=4 --force --options runtime --timestamp \
+                        --entitlements installers/macos/entitlements.plist \
+                        --sign "$CODESIGN_IDENTITY" "$file"
+                fi
+            done
         done
     fi
 }

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -36,9 +36,11 @@ chmod +x "$PKGROOT/usr/local/bin/PioneerConverter"
 if [[ -n "$CODESIGN_IDENTITY" ]]; then
   echo "Codesigning binaries"
   while IFS= read -r -d '' file; do
-      codesign --verbose=4 --force --options runtime --timestamp \
-        --entitlements "$(dirname "$0")/entitlements.plist" \
-        --sign "$CODESIGN_IDENTITY" "$file"
+      if file "$file" | grep -q 'Mach-O'; then
+        codesign --verbose=4 --force --options runtime --timestamp \
+          --entitlements "$(dirname "$0")/entitlements.plist" \
+          --sign "$CODESIGN_IDENTITY" "$file"
+      fi
     done < <(find "$PKGROOT/usr/local/$APPNAME" -type f -print0)
 fi
 

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -36,11 +36,9 @@ chmod +x "$PKGROOT/usr/local/bin/PioneerConverter"
 if [[ -n "$CODESIGN_IDENTITY" ]]; then
   echo "Codesigning binaries"
   while IFS= read -r -d '' file; do
-      if file "$file" | grep -q 'Mach-O'; then
-        codesign --verbose=4 --force --options runtime --timestamp \
-          --entitlements "$(dirname "$0")/entitlements.plist" \
-          --sign "$CODESIGN_IDENTITY" "$file"
-      fi
+      codesign --verbose=4 --force --options runtime --timestamp \
+        --entitlements "$(dirname "$0")/entitlements.plist" \
+        --sign "$CODESIGN_IDENTITY" "$file"
     done < <(find "$PKGROOT/usr/local/$APPNAME" -type f -print0)
 fi
 


### PR DESCRIPTION
## Summary
- sign macOS binaries during build
- notarize both pkg installers and zip archives
- staple notarization tickets for zips
- document revert in README, zipped binaries require chmod

## Testing
- `bash -n build.sh`
- `apt-get update >/tmp/apt.log && apt-get install -y yamllint >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687810797e8c8325b94c2c900dee9e55