### PR TITLE
Skip macOS binary archives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,12 @@ jobs:
         run: choco install innosetup -y
 
       - name: Build installers
-        run: ./build_installers.sh
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            SKIP_MAC_ZIPS=1 ./build_installers.sh
+          else
+            ./build_installers.sh
+          fi
         shell: bash
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
@@ -155,19 +160,6 @@ jobs:
           name: installer-windows
           path: installers/windows/PioneerConverter-win-*-Setup.exe
 
-      - name: Upload binary (mac arm64)
-        if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-mac-arm64
-          path: dist/PioneerConverter-osx-arm64-*.zip
-
-      - name: Upload binary (mac x64)
-        if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-mac-x64
-          path: dist/PioneerConverter-osx-x64-*.zip
 
       - name: Upload installer (mac arm64)
         if: matrix.os == 'macos-latest'

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ print_step() {
 }
 
 TARGET_OS="${1:-all}"
+SKIP_MAC_ZIPS="${SKIP_MAC_ZIPS:-0}"
 
 # Determine version from env or latest Git tag
 VERSION="${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")}"
@@ -92,6 +93,10 @@ esac
 print_step "Creating zip archives"
 cd dist
 for dir in "${BUILT[@]}"; do
+    if [[ "$SKIP_MAC_ZIPS" == "1" && "$dir" == PioneerConverter-osx-* ]]; then
+        echo "Skipping zip for $dir"
+        continue
+    fi
     if command -v zip >/dev/null 2>&1; then
         zip -r "${dir}-${VERSION}.zip" "$dir"
     elif command -v 7z >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- make the build script skip macOS zip archives when `SKIP_MAC_ZIPS` is set
- invoke the build script with that flag on macOS runners
- stop uploading macOS binary archives

## Testing
- `bash build.sh linux` *(fails: `dotnet: command not found`)*
- `apt-get update` *(fails: repository 403 errors due to networking restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68782a9d78288325be83d8095222dba0