### PR TITLE
Add GitHub Action step for macOS zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,25 +175,25 @@ jobs:
           name: installer-mac-x64
           path: installers/macos/PioneerConverter-x64-*.pkg
 
-macos_zip:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '8.0.x'
-    - name: Build macOS binaries
-      run: ./build.sh macos
-    - name: Upload binary (mac arm64)
-      uses: actions/upload-artifact@v4
-      with:
-        name: binary-osx-arm64
-        path: dist/PioneerConverter-osx-arm64-*.zip
-    - name: Upload binary (mac x64)
-      uses: actions/upload-artifact@v4
-      with:
-        name: binary-osx-x64
-        path: dist/PioneerConverter-osx-x64-*.zip
+  macos_zip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build macOS binaries
+        run: ./build.sh macos
+      - name: Upload binary (mac arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-osx-arm64
+          path: dist/PioneerConverter-osx-arm64-*.zip
+      - name: Upload binary (mac x64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-osx-x64
+          path: dist/PioneerConverter-osx-x64-*.zip
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,9 +175,29 @@ jobs:
           name: installer-mac-x64
           path: installers/macos/PioneerConverter-x64-*.pkg
 
+macos_zip:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+    - name: Build macOS binaries
+      run: ./build.sh macos
+    - name: Upload binary (mac arm64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-osx-arm64
+        path: dist/PioneerConverter-osx-arm64-*.zip
+    - name: Upload binary (mac x64)
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-osx-x64
+        path: dist/PioneerConverter-osx-x64-*.zip
+
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, macos_zip]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- build macOS binaries on Ubuntu without codesign
- upload macOS zip artifacts
- update release job dependencies

## Testing
- `./build.sh macos` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878341d63dc83259730ba177545464a