### PR TITLE
Fix linux wrapper script

### DIFF
--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -13,9 +13,9 @@ mkdir -p "$BUILD/usr/local/bin"
 
 cp -R ../../dist/PioneerConverter-linux-x64/* "$BUILD/usr/local/$APPNAME/"
 
-cat <<'WRAP' > "$BUILD/usr/local/bin/PioneerConverter"
+cat <<WRAP > "$BUILD/usr/local/bin/PioneerConverter"
 #!/bin/bash
-/usr/local/$APPNAME/PioneerConverter "$@"
+/usr/local/$APPNAME/PioneerConverter "\$@"
 WRAP
 chmod +x "$BUILD/usr/local/bin/PioneerConverter"
 


### PR DESCRIPTION
## Summary
- fix variable expansion in linux wrapper script so $APPNAME is replaced at build time

## Testing
- `dotnet --version` *(fails: command not found)*
- `bash installers/linux/build_deb.sh` *(fails: cp cannot stat `../../dist/PioneerConverter-linux-x64/*`)*

------
https://chatgpt.com/codex/tasks/task_e_687906f3cfcc83258047c60e1e3e72d5