### PR TITLE
Clean single-file releases and standardize metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,20 @@ jobs:
           name: binary-linux-x64
           path: dist/PioneerConverter-linux-x64-*.zip
 
+      - name: Upload binary (mac arm64)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-mac-arm64
+          path: dist/PioneerConverter-osx-arm64-*.zip
+
+      - name: Upload binary (mac x64)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-mac-x64
+          path: dist/PioneerConverter-osx-x64-*.zip
+
       - name: Upload installer (linux)
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4

--- a/PioneerConverter.csproj
+++ b/PioneerConverter.csproj
@@ -38,7 +38,7 @@
     <ItemGroup>
       <LibFiles Include="Libs\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(LibFiles)" DestinationFiles="@(LibFiles->'$(OutputPath)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(LibFiles)" DestinationFiles="@(LibFiles->'$(OutputPath)\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <!-- Also copy for publish -->
@@ -46,7 +46,7 @@
     <ItemGroup>
       <LibFiles Include="Libs\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(LibFiles)" DestinationFiles="@(LibFiles->'$(PublishDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(LibFiles)" DestinationFiles="@(LibFiles->'$(PublishDir)\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are three ways to get **PioneerConverter**:
     - macOS&nbsp;Intel (x64)
     - Linux (x64)
     - Windows (x64). 
-3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Extract them anywhere and, on Linux or macOS, you may need to run `chmod +x /path/to/PioneerConverter` before executing.
+3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Each archive contains a `bin` directory with the `PioneerConverter` executable and a `lib` directory with its dependencies. Extract them anywhere and, on Linux or macOS, you may need to run `chmod +x bin/PioneerConverter` before executing.
 4. **Build from source** – If you prefer to build the tool yourself, follow the steps in the [Build from source](#build-from-source) section below.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are three ways to get **PioneerConverter**:
     - macOS&nbsp;Intel (x64)
     - Linux (x64)
     - Windows (x64). 
-3. **Precompiled binaries** – Zipped binaries are available for Linux and Windows. Extract them anywhere and, on Linux, you may need to run `chmod +x /path/to/PioneerConverter` before executing. We currently do not publish zipped binaries for macOS due to Gatekeeper code‑signing restrictions.
+3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Extract them anywhere and, on Linux or macOS, you may need to run `chmod +x /path/to/PioneerConverter` before executing.
 4. **Build from source** – If you prefer to build the tool yourself, follow the steps in the [Build from source](#build-from-source) section below.
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ build_macos() {
       -r osx-arm64 \
       -p:PublishSingleFile=true \
       -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
       -p:DebugSymbols=false \
@@ -36,6 +37,7 @@ build_macos() {
       -r osx-x64 \
       -p:PublishSingleFile=true \
       -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
       -p:DebugSymbols=false \
@@ -52,6 +54,7 @@ build_linux() {
       -r linux-x64 \
       -p:PublishSingleFile=true \
       -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
       -p:DebugSymbols=false \
@@ -67,6 +70,7 @@ build_windows() {
       -r win-x64 \
       -p:PublishSingleFile=true \
       -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
       -p:DebugSymbols=false \

--- a/build.sh
+++ b/build.sh
@@ -23,16 +23,22 @@ build_macos() {
     print_step "Building for macOS ARM64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-arm64 \
-      -p:PublishSingleFile=false \
+      -p:PublishSingleFile=true \
+      -p:IncludeNativeLibrariesForSelfExtract=true \
       -p:PublishTrimmed=false \
+      -p:DebugType=None \
+      -p:DebugSymbols=false \
       --self-contained true \
       -o dist/PioneerConverter-osx-arm64
 
     print_step "Building for macOS x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-x64 \
-      -p:PublishSingleFile=false \
+      -p:PublishSingleFile=true \
+      -p:IncludeNativeLibrariesForSelfExtract=true \
       -p:PublishTrimmed=false \
+      -p:DebugType=None \
+      -p:DebugSymbols=false \
       --self-contained true \
       -o dist/PioneerConverter-osx-x64
 
@@ -44,8 +50,11 @@ build_linux() {
     print_step "Building for Linux x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r linux-x64 \
-      -p:PublishSingleFile=false \
+      -p:PublishSingleFile=true \
+      -p:IncludeNativeLibrariesForSelfExtract=true \
       -p:PublishTrimmed=false \
+      -p:DebugType=None \
+      -p:DebugSymbols=false \
       --self-contained true \
       -o dist/PioneerConverter-linux-x64
 
@@ -56,8 +65,11 @@ build_windows() {
     print_step "Building for Windows x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r win-x64 \
-      -p:PublishSingleFile=false \
+      -p:PublishSingleFile=true \
+      -p:IncludeNativeLibrariesForSelfExtract=true \
       -p:PublishTrimmed=false \
+      -p:DebugType=None \
+      -p:DebugSymbols=false \
       --self-contained true \
       -o dist/PioneerConverter-win-x64
 }

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,11 @@ build_macos() {
 
     chmod +x dist/PioneerConverter-osx-arm64/PioneerConverter
     chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
+
+    mkdir -p dist/PioneerConverter-osx-arm64/bin
+    mkdir -p dist/PioneerConverter-osx-x64/bin
+    mv dist/PioneerConverter-osx-arm64/PioneerConverter dist/PioneerConverter-osx-arm64/bin/
+    mv dist/PioneerConverter-osx-x64/PioneerConverter dist/PioneerConverter-osx-x64/bin/
 }
 
 build_linux() {
@@ -62,6 +67,8 @@ build_linux() {
       -o dist/PioneerConverter-linux-x64
 
     chmod +x dist/PioneerConverter-linux-x64/PioneerConverter
+    mkdir -p dist/PioneerConverter-linux-x64/bin
+    mv dist/PioneerConverter-linux-x64/PioneerConverter dist/PioneerConverter-linux-x64/bin/
 }
 
 build_windows() {
@@ -76,6 +83,9 @@ build_windows() {
       -p:DebugSymbols=false \
       --self-contained true \
       -o dist/PioneerConverter-win-x64
+
+    mkdir -p dist/PioneerConverter-win-x64/bin
+    mv dist/PioneerConverter-win-x64/PioneerConverter.exe dist/PioneerConverter-win-x64/bin/
 }
 
 BUILT=()

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -25,8 +25,8 @@ VERSION="${VERSION#v}"
 VERSION="$(echo "$VERSION" | tr -d '\n')"
 export VERSION
 
-# Build binaries only for the current platform
-./build.sh "$TARGET"
+# Build binaries for all platforms so macOS precompiled binaries are released
+./build.sh all
 
 case "$TARGET" in
     linux)

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -3,7 +3,10 @@ set -e
 
 APPNAME="PioneerConverter"
 VERSION="${VERSION:-1.0.0}"
-ARCH="amd64"
+# Architecture used inside the Debian control file
+ARCH_DEB="amd64"
+# Architecture label used for generated package filenames
+ARCH_OUT="x64"
 BUILD="debian"
 
 rm -rf "$BUILD"
@@ -24,11 +27,11 @@ Package: pioneerconverter
 Version: $VERSION
 Section: utils
 Priority: optional
-Architecture: $ARCH
-Maintainer: Unknown
+Architecture: $ARCH_DEB
+Maintainer: edu.washu.goldfarblab.pioneerconverter
 Description: PioneerConverter command line tool
 CTRL
 
-dpkg-deb --build "$BUILD" "${APPNAME}-linux_${VERSION}_${ARCH}.deb"
+dpkg-deb --build "$BUILD" "${APPNAME}-linux-${ARCH_OUT}-${VERSION}.deb"
 
-echo "Package created: ${APPNAME}-linux_${VERSION}_${ARCH}.deb"
+echo "Package created: ${APPNAME}-linux-${ARCH_OUT}-${VERSION}.deb"

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -18,7 +18,7 @@ cp -R ../../dist/PioneerConverter-linux-x64/* "$BUILD/usr/local/$APPNAME/"
 
 cat <<WRAP > "$BUILD/usr/local/bin/PioneerConverter"
 #!/bin/bash
-/usr/local/$APPNAME/PioneerConverter "\$@"
+  /usr/local/$APPNAME/bin/PioneerConverter "\$@"
 WRAP
 chmod +x "$BUILD/usr/local/bin/PioneerConverter"
 

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -29,7 +29,7 @@ cp -R "$DIST"/* "$PKGROOT/usr/local/$APPNAME/"
 
 cat <<WRAP > "$PKGROOT/usr/local/bin/PioneerConverter"
 #!/bin/bash
-/usr/local/$APPNAME/PioneerConverter "\$@"
+/usr/local/$APPNAME/bin/PioneerConverter "\$@"
 WRAP
 chmod +x "$PKGROOT/usr/local/bin/PioneerConverter"
 

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -47,7 +47,7 @@ fi
 UNSIGNED="${PKGFILE%.pkg}-unsigned.pkg"
 
 pkgbuild --root "$PKGROOT" \
-  --identifier "com.example.pioneerconverter" \
+  --identifier "edu.washu.goldfarblab.pioneerconverter" \
   --version "$VERSION" \
   --install-location "/" "$UNSIGNED"
 

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -24,7 +24,7 @@ Source: "..\..\dist\PioneerConverter-win-x64\*"; DestDir: "{app}"; Flags: recurs
 Name: "addtopath"; Description: "Add application directory to PATH"; Flags: unchecked
 
 [Registry]
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}"; Flags: preservestringtype; Tasks: addtopath
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\bin"; Flags: preserve stringtype; Tasks: addtopath
 
 [Icons]
-Name: "{group}\PioneerConverter"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\PioneerConverter"; Filename: "{app}\bin\{#MyAppExeName}"

--- a/installers/windows/PioneerConverter.iss
+++ b/installers/windows/PioneerConverter.iss
@@ -18,13 +18,13 @@ SolidCompression=yes
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "..\..\dist\PioneerConverter-win-x64\*"; DestDir: "{app}"; Flags: recursesubdirs
+Source: "..\\..\\dist\\PioneerConverter-win-x64\\*"; DestDir: "{app}"; Flags: recursesubdirs
 
 [Tasks]
 Name: "addtopath"; Description: "Add application directory to PATH"; Flags: unchecked
 
 [Registry]
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\bin"; Flags: preserve stringtype; Tasks: addtopath
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\bin"; Flags: preservestringtype; Tasks: addtopath
 
 [Icons]
-Name: "{group}\PioneerConverter"; Filename: "{app}\bin\{#MyAppExeName}"
+Name: "{group}\\PioneerConverter"; Filename: "{app}\\bin\\{#MyAppExeName}"


### PR DESCRIPTION
## Summary
- Name Linux deb packages with `x64` and set maintainer identifier to `edu.washu.goldfarblab.pioneerconverter`
- Publish single-file binaries for all platforms for tidy bin directories
- Build installers with cross-platform binaries and update macOS package identifier
- Note macOS zipped binaries in README

## Testing
- `./build.sh linux` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: repository InRelease not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_688e3443dcb88325b26b9172f39ad1a0