### PR TITLE
Remove unnecessary XML documentation from distribution

### DIFF
--- a/PioneerConverter.csproj
+++ b/PioneerConverter.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -33,10 +33,11 @@
     </Reference>
   </ItemGroup>
 
-  <!-- Copy all necessary files -->
+  <!-- Copy runtime libraries only -->
   <Target Name="CopyAllFiles" BeforeTargets="Build">
     <ItemGroup>
-      <LibFiles Include="Libs\**\*.*" />
+      <!-- Include managed and native libraries but skip docs and packages -->
+      <LibFiles Include="Libs\**\*.dll;Libs\**\*.so;Libs\**\*.dylib" />
     </ItemGroup>
     <Copy SourceFiles="@(LibFiles)" DestinationFiles="@(LibFiles->'$(OutputPath)\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
@@ -44,9 +45,26 @@
   <!-- Also copy for publish -->
   <Target Name="CopyAllFilesOnPublish" BeforeTargets="Publish">
     <ItemGroup>
-      <LibFiles Include="Libs\**\*.*" />
+      <!-- Include managed and native libraries but skip docs and packages -->
+      <LibFiles Include="Libs\**\*.dll;Libs\**\*.so;Libs\**\*.dylib" />
     </ItemGroup>
     <Copy SourceFiles="@(LibFiles)" DestinationFiles="@(LibFiles->'$(PublishDir)\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+
+  <!-- Remove documentation and package files from build output -->
+  <Target Name="RemoveNonRuntimeFiles" AfterTargets="Build">
+    <ItemGroup>
+      <UnneededFiles Include="$(OutputPath)\*.xml;$(OutputPath)\*.pdb;$(OutputPath)\*.nupkg" />
+    </ItemGroup>
+    <Delete Files="@(UnneededFiles)" />
+  </Target>
+
+  <!-- Remove documentation and package files from publish output -->
+  <Target Name="RemoveNonRuntimeFilesOnPublish" AfterTargets="Publish">
+    <ItemGroup>
+      <UnneededFiles Include="$(PublishDir)\*.xml;$(PublishDir)\*.pdb;$(PublishDir)\*.nupkg" />
+    </ItemGroup>
+    <Delete Files="@(UnneededFiles)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Summary
- avoid copying XML and package files to build/publish output
- remove extraneous documentation and package artifacts after build and publish

## Testing
- `dotnet publish PioneerConverter.csproj -c Release -r linux-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishReadyToRun=false -p:PublishTrimmed=false -p:DebugType=None -p:DebugSymbols=false --self-contained true -o publish_test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e45776e048325bc0991034855ed99