### PR TITLE
Fix Inno Setup invocation for Windows build

### DIFF
--- a/build_installers.sh
+++ b/build_installers.sh
@@ -50,7 +50,7 @@ case "$TARGET" in
         echo "Debug: MSYS2_ARG_CONV_EXCL=${MSYS2_ARG_CONV_EXCL}"
         echo "Debug: running iscc with /DMyAppVersion=${VERSION} PioneerConverter.iss via cmd.exe"
         echo "Debug: directory contents:" && ls -1
-        cmd.exe //C iscc "/DMyAppVersion=${VERSION}" "PioneerConverter.iss"
+        cmd.exe //C "iscc /DMyAppVersion=${VERSION} PioneerConverter.iss"
         mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         popd > /dev/null
         ;;

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -45,11 +45,7 @@ case "$TARGET" in
     windows)
         echo "Creating Windows installer"
         pushd installers/windows > /dev/null
-        echo "Debug: iscc path: $(command -v iscc)"
         export MSYS2_ARG_CONV_EXCL="/D*"
-        echo "Debug: MSYS2_ARG_CONV_EXCL=${MSYS2_ARG_CONV_EXCL}"
-        echo "Debug: running iscc with /DMyAppVersion=${VERSION} PioneerConverter.iss via cmd.exe"
-        echo "Debug: directory contents:" && ls -1
         cmd.exe //C "iscc /DMyAppVersion=${VERSION} PioneerConverter.iss"
         mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         popd > /dev/null

--- a/build_installers.sh
+++ b/build_installers.sh
@@ -48,9 +48,9 @@ case "$TARGET" in
         echo "Debug: iscc path: $(command -v iscc)"
         export MSYS2_ARG_CONV_EXCL="/D*"
         echo "Debug: MSYS2_ARG_CONV_EXCL=${MSYS2_ARG_CONV_EXCL}"
-        echo "Debug: running iscc with /DMyAppVersion=${VERSION} PioneerConverter.iss"
+        echo "Debug: running iscc with /DMyAppVersion=${VERSION} PioneerConverter.iss via cmd.exe"
         echo "Debug: directory contents:" && ls -1
-        iscc /DMyAppVersion=${VERSION} PioneerConverter.iss
+        cmd.exe //C iscc "/DMyAppVersion=${VERSION}" "PioneerConverter.iss"
         mv "Output/PioneerConverter-win-${VERSION}-Setup.exe" "PioneerConverter-win-${VERSION}-Setup.exe"
         popd > /dev/null
         ;;


### PR DESCRIPTION
## Summary
- run Inno Setup through `cmd.exe` to prevent multiple script filename errors when packaging

## Testing
- `./build.sh linux` *(fails: `dotnet: command not found`)*
- `apt-get update` *(fails: repository 'noble' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e7e06a0b8832583e34f32475d547f