### PR TITLE
Fix Linux .deb naming to place version at end

### DIFF
--- a/installers/linux/README.md
+++ b/installers/linux/README.md
@@ -10,5 +10,5 @@ Run the script on a Debian-based system:
 ./build_deb.sh
 ```
 
-The resulting `PioneerConverter-linux_<version>_x64.deb` can be installed
+The resulting `PioneerConverter-linux-x64-<version>.deb` can be installed
 with `dpkg -i` where `<version>` is the release tag.

--- a/installers/linux/build_deb.sh
+++ b/installers/linux/build_deb.sh
@@ -32,6 +32,6 @@ Maintainer: edu.washu.goldfarblab.pioneerconverter
 Description: PioneerConverter command line tool
 CTRL
 
-dpkg-deb --build "$BUILD" "${APPNAME}-linux_${VERSION}_${ARCH_PKG}.deb"
+dpkg-deb --build "$BUILD" "${APPNAME}-linux-${ARCH_PKG}-${VERSION}.deb"
 
-echo "Package created: ${APPNAME}-linux_${VERSION}_${ARCH_PKG}.deb"
+echo "Package created: ${APPNAME}-linux-${ARCH_PKG}-${VERSION}.deb"


### PR DESCRIPTION
## Summary
- Rename Linux `.deb` build to use `PioneerConverter-linux-x64-<version>.deb`
- Update Linux installer README to document new filename pattern

## Testing
- `bash -n installers/linux/build_deb.sh`
- `./build.sh linux` *(fails: dotnet: command not found)*
- `./installers/linux/build_deb.sh` *(fails: cannot stat '../../dist/PioneerConverter-linux-x64/*')*


------
https://chatgpt.com/codex/tasks/task_e_688e88cc93f8832593400d3bf10c31d5