### PR TITLE
Allow manual release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build Installers
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.2.3)'
+        required: false
   push:
     tags:
       - 'v*'
@@ -97,6 +101,7 @@ jobs:
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
           PKG_SIGN_IDENTITY: ${{ secrets.PKG_SIGN_IDENTITY }}
+          VERSION: ${{ github.event.inputs.tag }}
 
       - name: Notarize macOS package
         if: matrix.os == 'macos-latest'
@@ -192,7 +197,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.tag != ''
+    env:
+      TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v3
 
@@ -204,7 +211,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="$TAG_NAME"
           gh release view "$tag" >/dev/null 2>&1 || \
             gh release create "$tag" -t "$tag" -n "Release $tag"
 
@@ -212,7 +219,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="$TAG_NAME"
           for file in artifacts/binary-*/*; do
             name="$(basename "$file")"
             gh release upload "$tag" "$file#$name" --clobber
@@ -222,7 +229,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="$TAG_NAME"
           for file in artifacts/installer-*/*; do
             base="$(basename "$file")"
             dir="$(basename "$(dirname "$file")")"


### PR DESCRIPTION
## Summary
- allow manual releases by tagging via workflow dispatch

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890ec9d2de48325b58ffa56f6c59279