### PR TITLE
Minimize macOS bundles and enforce single-file builds

### DIFF
--- a/PioneerConverter.csproj
+++ b/PioneerConverter.csproj
@@ -35,6 +35,11 @@
     </Reference>
   </ItemGroup>
 
+  <!-- Prevent test sources (including generated obj files) from being compiled into the app -->
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+  </ItemGroup>
+
   <!-- Copy runtime libraries only -->
   <Target Name="CopyAllFiles" BeforeTargets="Build">
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ There are three ways to get **PioneerConverter**:
     - Windows (x64). 
 
    On Apple Silicon, Thermo RawFileReader is x64-only, so PioneerConverter runs via Rosetta 2.
+   The macOS arm64 installer will install Rosetta automatically when needed.
 3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Each archive contains a `bin` directory with the `PioneerConverter` executable and a `lib` directory with its dependencies. Extract them anywhere and, on Linux or macOS, you may need to run `chmod +x bin/PioneerConverter` before executing.
 4. **Build from source** – If you prefer to build the tool yourself, follow the steps in the [Build from source](#build-from-source) section below.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ There are three ways to get **PioneerConverter**:
     - macOS&nbsp;Intel (x64)
     - Linux (x64)
     - Windows (x64). 
+
+   On Apple Silicon, Thermo RawFileReader is x64-only, so PioneerConverter runs via Rosetta 2.
 3. **Precompiled binaries** – Zipped binaries are available for Linux, macOS, and Windows. Each archive contains a `bin` directory with the `PioneerConverter` executable and a `lib` directory with its dependencies. Extract them anywhere and, on Linux or macOS, you may need to run `chmod +x bin/PioneerConverter` before executing.
 4. **Build from source** – If you prefer to build the tool yourself, follow the steps in the [Build from source](#build-from-source) section below.
 

--- a/build.sh
+++ b/build.sh
@@ -26,8 +26,7 @@ build_macos() {
     print_step "Building for macOS ARM64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-arm64 \
-      -p:PublishSingleFile=true \
-      -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishSingleFile=false \
       -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
@@ -39,8 +38,7 @@ build_macos() {
     print_step "Building for macOS x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-x64 \
-      -p:PublishSingleFile=true \
-      -p:IncludeNativeLibrariesForSelfExtract=true \
+      -p:PublishSingleFile=false \
       -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
@@ -49,12 +47,13 @@ build_macos() {
       --self-contained true \
       -o dist/PioneerConverter-osx-x64
 
-    chmod +x dist/PioneerConverter-osx-arm64/PioneerConverter
-    chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
     mkdir -p dist/PioneerConverter-osx-arm64/bin
     mkdir -p dist/PioneerConverter-osx-x64/bin
-    mv dist/PioneerConverter-osx-arm64/PioneerConverter dist/PioneerConverter-osx-arm64/bin/
-    mv dist/PioneerConverter-osx-x64/PioneerConverter dist/PioneerConverter-osx-x64/bin/
+    # For non-single-file macOS publishes, the runtime payload must live with the executable.
+    find dist/PioneerConverter-osx-arm64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec mv {} dist/PioneerConverter-osx-arm64/bin/ \;
+    find dist/PioneerConverter-osx-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec mv {} dist/PioneerConverter-osx-x64/bin/ \;
+    chmod +x dist/PioneerConverter-osx-arm64/bin/PioneerConverter
+    chmod +x dist/PioneerConverter-osx-x64/bin/PioneerConverter
     # Keep macOS release layout minimal: only bin/ and lib/
     find dist/PioneerConverter-osx-arm64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec rm -rf {} +
     find dist/PioneerConverter-osx-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec rm -rf {} +

--- a/build.sh
+++ b/build.sh
@@ -21,10 +21,13 @@ VERSION="$(echo "$VERSION" | tr -d '\n')"
 mkdir -p dist
 
 build_macos() {
+    rm -rf dist/PioneerConverter-osx-arm64 dist/PioneerConverter-osx-x64
+
     print_step "Building for macOS ARM64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-arm64 \
-      -p:PublishSingleFile=false \
+      -p:PublishSingleFile=true \
+      -p:IncludeNativeLibrariesForSelfExtract=true \
       -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
@@ -36,7 +39,8 @@ build_macos() {
     print_step "Building for macOS x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-x64 \
-      -p:PublishSingleFile=false \
+      -p:PublishSingleFile=true \
+      -p:IncludeNativeLibrariesForSelfExtract=true \
       -p:PublishReadyToRun=false \
       -p:PublishTrimmed=false \
       -p:DebugType=None \
@@ -47,9 +51,18 @@ build_macos() {
 
     chmod +x dist/PioneerConverter-osx-arm64/PioneerConverter
     chmod +x dist/PioneerConverter-osx-x64/PioneerConverter
+    mkdir -p dist/PioneerConverter-osx-arm64/bin
+    mkdir -p dist/PioneerConverter-osx-x64/bin
+    mv dist/PioneerConverter-osx-arm64/PioneerConverter dist/PioneerConverter-osx-arm64/bin/
+    mv dist/PioneerConverter-osx-x64/PioneerConverter dist/PioneerConverter-osx-x64/bin/
+    # Keep macOS release layout minimal: only bin/ and lib/
+    find dist/PioneerConverter-osx-arm64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec rm -rf {} +
+    find dist/PioneerConverter-osx-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec rm -rf {} +
 }
 
 build_linux() {
+    rm -rf dist/PioneerConverter-linux-x64
+
     print_step "Building for Linux x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r linux-x64 \
@@ -69,6 +82,8 @@ build_linux() {
 }
 
 build_windows() {
+    rm -rf dist/PioneerConverter-win-x64
+
     print_step "Building for Windows x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r win-x64 \
@@ -121,12 +136,14 @@ for dir in "${BUILT[@]}"; do
         echo "Skipping zip for $dir"
         continue
     fi
+    archive="${dir}-${VERSION}.zip"
+    rm -f "$archive"
     if command -v zip >/dev/null 2>&1; then
-        zip -r "${dir}-${VERSION}.zip" "$dir"
+        zip -r "$archive" "$dir"
     elif command -v 7z >/dev/null 2>&1; then
-        7z a "${dir}-${VERSION}.zip" "$dir" >/dev/null
+        7z a "$archive" "$dir" >/dev/null
     elif command -v powershell.exe >/dev/null 2>&1; then
-        powershell.exe -Command "Compress-Archive -Path '$dir' -DestinationPath '${dir}-${VERSION}.zip'" >/dev/null
+        powershell.exe -Command "Compress-Archive -Path '$dir' -DestinationPath '$archive'" >/dev/null
     else
         echo "No zip utility found" >&2
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -23,18 +23,6 @@ mkdir -p dist
 build_macos() {
     rm -rf dist/PioneerConverter-osx-arm64 dist/PioneerConverter-osx-x64
 
-    print_step "Building for macOS ARM64"
-    dotnet publish PioneerConverter.csproj -c Release \
-      -r osx-arm64 \
-      -p:PublishSingleFile=false \
-      -p:PublishReadyToRun=false \
-      -p:PublishTrimmed=false \
-      -p:DebugType=None \
-      -p:DebugSymbols=false \
-      -p:Version="${VERSION}" \
-      --self-contained true \
-      -o dist/PioneerConverter-osx-arm64
-
     print_step "Building for macOS x64"
     dotnet publish PioneerConverter.csproj -c Release \
       -r osx-x64 \
@@ -47,16 +35,14 @@ build_macos() {
       --self-contained true \
       -o dist/PioneerConverter-osx-x64
 
-    mkdir -p dist/PioneerConverter-osx-arm64/bin
     mkdir -p dist/PioneerConverter-osx-x64/bin
     # For non-single-file macOS publishes, the runtime payload must live with the executable.
-    find dist/PioneerConverter-osx-arm64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec mv {} dist/PioneerConverter-osx-arm64/bin/ \;
     find dist/PioneerConverter-osx-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec mv {} dist/PioneerConverter-osx-x64/bin/ \;
-    chmod +x dist/PioneerConverter-osx-arm64/bin/PioneerConverter
     chmod +x dist/PioneerConverter-osx-x64/bin/PioneerConverter
-    # Keep macOS release layout minimal: only bin/ and lib/
-    find dist/PioneerConverter-osx-arm64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec rm -rf {} +
-    find dist/PioneerConverter-osx-x64 -mindepth 1 -maxdepth 1 ! -name bin ! -name lib -exec rm -rf {} +
+
+    # RawFileReader's .NET assemblies are x64-only on macOS. Ship the same x64 payload
+    # in the arm64 archive/package so Apple Silicon runs under Rosetta.
+    cp -R dist/PioneerConverter-osx-x64 dist/PioneerConverter-osx-arm64
 }
 
 build_linux() {

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -4,7 +4,8 @@ The `build_pkg.sh` script generates a `.pkg` installer using `pkgbuild`.
 The installer places files under `/usr/local/PioneerConverter` and installs a wrapper script `PioneerConverter` into `/usr/local/bin` so the command is on your `PATH`.
 
 On Apple Silicon, Thermo RawFileReader dependencies are x64-only, so the installed
-converter runs via Rosetta 2.
+converter runs via Rosetta 2. The arm64 package runs a `preinstall` script that
+installs Rosetta automatically if it is missing.
 
 ## Building
 

--- a/installers/macos/README.md
+++ b/installers/macos/README.md
@@ -3,6 +3,9 @@
 The `build_pkg.sh` script generates a `.pkg` installer using `pkgbuild`.
 The installer places files under `/usr/local/PioneerConverter` and installs a wrapper script `PioneerConverter` into `/usr/local/bin` so the command is on your `PATH`.
 
+On Apple Silicon, Thermo RawFileReader dependencies are x64-only, so the installed
+converter runs via Rosetta 2.
+
 ## Building
 
 Run the script on macOS with Xcode command line tools installed:

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -29,7 +29,7 @@ cp -R "$DIST"/* "$PKGROOT/usr/local/$APPNAME/"
 
 cat <<WRAP > "$PKGROOT/usr/local/bin/PioneerConverter"
 #!/bin/bash
-/usr/local/$APPNAME/PioneerConverter "\$@"
+/usr/local/$APPNAME/bin/PioneerConverter "\$@"
 WRAP
 chmod +x "$PKGROOT/usr/local/bin/PioneerConverter"
 

--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -5,11 +5,13 @@ APPNAME="PioneerConverter"
 VERSION="${VERSION:-1.0.0}"
 PKGROOT="pkgroot"
 PKG_ARCH="${PKG_ARCH:-$(uname -m)}"
+PKGSCRIPTS=""
 
 case "$PKG_ARCH" in
   arm64|aarch64)
     DIST="../../dist/${APPNAME}-osx-arm64"
     PKGFILE="${APPNAME}-arm64-${VERSION}.pkg"
+    PKGSCRIPTS="$(dirname "$0")/scripts/arm64"
     ;;
   x64|x86_64)
     DIST="../../dist/${APPNAME}-osx-x64"
@@ -45,11 +47,18 @@ if [[ -n "$CODESIGN_IDENTITY" ]]; then
 fi
 
 UNSIGNED="${PKGFILE%.pkg}-unsigned.pkg"
+PKGBUILD_EXTRA_ARGS=()
+
+if [[ -n "$PKGSCRIPTS" ]]; then
+  PKGBUILD_EXTRA_ARGS+=(--scripts "$PKGSCRIPTS")
+fi
 
 pkgbuild --root "$PKGROOT" \
   --identifier "edu.washu.goldfarblab.pioneerconverter" \
   --version "$VERSION" \
-  --install-location "/" "$UNSIGNED"
+  --install-location "/" \
+  "${PKGBUILD_EXTRA_ARGS[@]}" \
+  "$UNSIGNED"
 
 if [[ -n "$PKG_SIGN_IDENTITY" ]]; then
   echo "Signing package"

--- a/installers/macos/scripts/arm64/preinstall
+++ b/installers/macos/scripts/arm64/preinstall
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# PioneerConverter's Thermo dependency is x64-only on macOS, so arm64 installs
+# require Rosetta to be present before first launch.
+if [[ "$(/usr/bin/uname -m)" != "arm64" ]]; then
+  exit 0
+fi
+
+if /usr/sbin/pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto >/dev/null 2>&1; then
+  echo "Rosetta 2 already installed."
+  exit 0
+fi
+
+echo "Installing Rosetta 2 (required for PioneerConverter on Apple Silicon)..."
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+
+if /usr/sbin/pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto >/dev/null 2>&1; then
+  echo "Rosetta 2 installation complete."
+  exit 0
+fi
+
+echo "Rosetta 2 installation failed." >&2
+exit 1


### PR DESCRIPTION
**Summary**
- prevent test sources from leaking into the app build and ensure macOS builds are always cleaned before publishing
- build macOS targets as single-file apps with native libraries bundled for self-extracting deployment, then move binaries into `bin/` and prune other top-level artifacts so zips stay minimal
- make zip creation deterministic by removing stale archives before packaging and point the macOS pkg shim to the new binary location

**Testing**
- Not run (not requested)